### PR TITLE
Changes because test error

### DIFF
--- a/docker-nodejs/delivery-service/src/frameworks/db/sequelize.js
+++ b/docker-nodejs/delivery-service/src/frameworks/db/sequelize.js
@@ -37,7 +37,7 @@ class SequelizeClient {
 
   }
 
-  syncDatabase() {
+  async syncDatabase() {
 
     // Crea las tablas que no existan en la base de datos en base a los modelos definidos.
 
@@ -45,7 +45,7 @@ class SequelizeClient {
       alter: false,
     };
 
-    this.sequelize.sync(syncOptions)
+    await this.sequelize.sync(syncOptions)
       .catch(error => {
         console.log("Couldn't sync database", error);
       });

--- a/docker-nodejs/ecommerce-service/src/frameworks/db/sequelize.js
+++ b/docker-nodejs/ecommerce-service/src/frameworks/db/sequelize.js
@@ -37,7 +37,7 @@ class SequelizeClient {
 
   }
 
-  syncDatabase() {
+  async syncDatabase() {
 
     // Crea las tablas que no existan en la base de datos en base a los modelos definidos.
 
@@ -45,7 +45,7 @@ class SequelizeClient {
       alter: false,
     };
 
-    this.sequelize.sync(syncOptions)
+    await this.sequelize.sync(syncOptions)
       .catch(error => {
         console.log("Couldn't sync database", error);
       });


### PR DESCRIPTION
When I run "npm run test" there is an error in respositories/sequalize. The table doesn't exist when the tests are running. 
![image](https://user-images.githubusercontent.com/39566250/173374382-09c33d9f-73a0-43dd-a4c2-36ef99df790e.png)

It happens because the function syncDatabase() don't make the sync() in a syncronus way. It allows tests to run before the promise of sync don't be result (don't check and create tables).